### PR TITLE
chore: revert to stable .NET and disallow preview versions in renovate

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-preview.1.24101.2",
+    "version": "8.0.204",
     "rollForward": "latestMinor"
   },
   "msbuild-sdks": {

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,12 @@
     },
     {
       "matchPackagePrefixes": [
+        "dotnet-sdk"
+      ],
+      "allowedVersions": "!/preview/"
+    },
+    {
+      "matchPackagePrefixes": [
         "GodotSharp",
         "Godot.NET.Sdk"
       ],


### PR DESCRIPTION
Reverted project to current stable .NET SDK (8.0.204) and added a rule to prevent renovate from updating to preview versions.

Would suggest waiting to merge until we verify that chickensoft-games/GodotPackage#95 works as intended, since this PR is essentially the same.

(Spellcheck is failing, but a separate fix for that exists in #43.)