### PR TITLE
Support context messages for errors

### DIFF
--- a/Chickensoft.GoDotLog.Tests/test/src/LogTest.cs
+++ b/Chickensoft.GoDotLog.Tests/test/src/LogTest.cs
@@ -118,6 +118,21 @@ public class LogTest : TestClass {
   }
 
   [Test]
+  public void PrintsExceptionWithMessage() {
+    Setup();
+    var e = new InvalidOperationException("message");
+    var log = new GDLog("Prefix");
+    log.Print(e, "Override message");
+    var output = string.Join(_ln, new string[] {
+      "Prefix: Override message",
+      $"Prefix: System.InvalidOperationException: message{_ln}"
+    });
+    _print.ToString().ShouldBe(output);
+    _error.ToString().ShouldBe(output);
+    Cleanup();
+  }
+
+  [Test]
   public void Warns() {
     Setup();
     var log = new GDLog("Prefix");

--- a/Chickensoft.GoDotLog/src/GDLog.cs
+++ b/Chickensoft.GoDotLog/src/GDLog.cs
@@ -73,6 +73,13 @@ public sealed partial class GDLog : ILog {
 
   /// <inheritdoc/>
   [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  public void Print(Exception e, string message) {
+    Err(message);
+    Err(e.ToString());
+  }
+
+  /// <inheritdoc/>
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
   public void Warn(string message) {
     PrintAction(Prefix + ": " + message);
     PushWarningAction(Prefix + ": " + message);

--- a/Chickensoft.GoDotLog/src/ILog.cs
+++ b/Chickensoft.GoDotLog/src/ILog.cs
@@ -27,6 +27,16 @@ public interface ILog {
   void Print(Exception e);
 
   /// <summary>
+  /// Prints an exception with a message for context.
+  /// </summary>
+  /// <param name="e">Exception to print.</param>
+  /// <param name="message">Message to output.</param>
+  void Print(Exception e, string message) {
+    Print(message);
+    Print(e);
+  }
+
+  /// <summary>
   /// Adds a warning message to the log.
   /// </summary>
   /// <param name="message">Message to output.</param>


### PR DESCRIPTION
Based on discussion on the ChickenSoft Discord, here's a proposal for setting specific error messages when logging Exceptions.

The implementation in `GDLog` is the intended behavior, replacing the default message with the (presumably) more specific one provided by the caller.

The implementation in `ILog` exists to enable backward-compatibility - it's not the ideal form, but it means that this is not a breaking change to `ILog` consumers.